### PR TITLE
Upgrade Python to 3.10

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8.8
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.8.8'
+        python-version: '3.10'
     - name: Install poetry
       uses: abatilo/actions-poetry@v2.0.0
       with:


### PR DESCRIPTION
Fixes [this](https://github.com/EthanRosenthal/discovered-weekly/actions/runs/3570261386) failing build. This change also relaxes the python version to only pin to the minor version.